### PR TITLE
Feat/checkout 주문 완료 페이지 만들기

### DIFF
--- a/src/api/cart.ts
+++ b/src/api/cart.ts
@@ -10,6 +10,7 @@ import {
 import { db } from './firebase';
 import { AddCartProductType, CartItemType, ProductSize } from 'types/product';
 import { QueryFunction } from '@tanstack/react-query';
+import { Address, Receiver } from 'types/auth';
 
 export const getMyCart: QueryFunction<
   CartItemType[],
@@ -66,17 +67,73 @@ export const deleteFromCart = async ({
   product,
 }: {
   uid: string;
-  product: CartItemType;
+  product?: CartItemType;
 }) => {
+  if (uid && !product) {
+    const docRef = collection(db, 'carts', uid, 'products');
+    const querySnapshot = await getDocs(docRef);
+    querySnapshot.forEach(async (docSnap) => {
+      await deleteDoc(docSnap.ref);
+    });
+    return;
+  }
   const docRef = collection(db, 'carts', uid, 'products');
   const q = query(
     docRef,
-    where('id', '==', product.id),
-    where('size', '==', product.size),
+    where('id', '==', product?.id),
+    where('size', '==', product?.size),
   );
   const querySnapshot = await getDocs(q);
   querySnapshot.forEach(async (docSnap) => {
     const docRef = doc(db, 'carts', uid, 'products', docSnap.id);
     await deleteDoc(docRef);
   });
+};
+
+const createOrderId = () => {
+  const year = new Date().getFullYear();
+  const month = new Date().getMonth() + 1;
+  const date = new Date().getDate();
+  const time = new Date().getTime();
+  return `ORD${year}${month}${date}-${time}`;
+};
+
+export const saveOrder = async ({
+  uid,
+  products,
+  receiver,
+  address,
+  price,
+}: {
+  uid: string;
+  products: CartItemType[];
+  receiver: Receiver;
+  address: Address;
+  price: number;
+}) => {
+  const { phone1, phone2 } = receiver;
+  const shipping = price >= 70000 ? 0 : 3000;
+  const order = {
+    orderId: createOrderId(),
+    orderDate: new Date(),
+    products,
+    payment: {
+      price,
+      shipping,
+      total: price + shipping,
+    },
+    buyer: {
+      name: receiver.name,
+      address,
+      phone: `${phone1.part1}-${phone1.part2}-${phone1.part3}`,
+      ...(phone2?.part1 &&
+        phone2?.part2 &&
+        phone2?.part3 && {
+          phone2: `${phone2.part1}-${phone2.part2}-${phone2.part3}`,
+        }),
+    },
+  };
+  const orderRef = doc(collection(db, 'orders', uid, order.orderId));
+  await setDoc(orderRef, order);
+  return order.orderId;
 };

--- a/src/components/OrderProcess.tsx
+++ b/src/components/OrderProcess.tsx
@@ -6,18 +6,24 @@ const OrderProcess = () => {
   const process = ['01 SHOPPING BAG', '02 ORDER', '03 ORDER CONFIRMED'];
   const fontBold = (index: number) => {
     if (pathname === '/carts' && index === 0) {
-      return 'font-bold';
+      return true;
     }
     if (pathname === '/checkout' && index === 1) {
-      return 'font-bold';
+      return true;
     }
-    return '';
+    if (pathname.startsWith('/order') && index === 2) {
+      return true;
+    }
+    return false;
   };
   return (
     <div className='hidden md:visible md:flex justify-center pt-20 pb-24'>
       <ol className='flex gap-2 text-[15px]'>
         {process.map((p, i) => (
-          <li key={i} className={`flex items-center gap-2 ${fontBold(i)}`}>
+          <li
+            key={i}
+            className={`flex items-center gap-2 ${fontBold(i) ? 'font-semibold text-black' : 'text-very-light-gray'}`}
+          >
             {p}
             {i !== process.length - 1 && <ArrowSvg width={8} height={16} />}
           </li>

--- a/src/components/OrderProducts.tsx
+++ b/src/components/OrderProducts.tsx
@@ -1,0 +1,61 @@
+import { Link } from 'react-router-dom';
+import { CartItemType } from 'types/product';
+
+const OrderProducts = ({ products }: { products: CartItemType[] }) => {
+  return (
+    <section>
+      <h3 className='text-xl mb-3'>
+        {`주문 상품 정보 / ${products.length}개 상품`}
+      </h3>
+      <div className='border-t-2 border-black'>
+        <ul>
+          <li className='w-full table table-fixed text-sm border-b border-gray-950 leading-[60px]'>
+            <div className='w-8/12 relative table-cell text-center'>
+              <div className='flex items-center justify-between'>
+                <span className='w-24'>상품</span>
+                <span className='flex-1'>상품 정보</span>
+              </div>
+            </div>
+            <div className='table-cell'>수량</div>
+            <div className='table-cell'>진행 상태</div>
+          </li>
+          {products?.map((product) => {
+            const { id, name, image, price, size, quantity } = product;
+            return (
+              <>
+                <li className='w-full table table-fixed py-6 border-b last:border-b-2 border-b-black'>
+                  <div className='w-8/12 relative table-cell text-center text-base md:text-xl'>
+                    <Link to={`/products/${id}`} className='flex items-center'>
+                      <img
+                        src={image}
+                        className='w-24 h-24 mr-5 object-cover'
+                        alt='상품 이미지'
+                      />
+                      <div>
+                        <h3 className='pt-6 pb-2'>{name}</h3>
+                        <p className='text-price-stress font-bold'>
+                          {`${price.toLocaleString()}원`}
+                        </p>
+                        <ul className='mt-2 mb-1'>
+                          <li className='text-xs'>옵션:{size}</li>
+                        </ul>
+                      </div>
+                    </Link>
+                  </div>
+                  <div className='table-cell align-middle text-sm md:text-base font-bold'>
+                    {quantity}
+                  </div>
+                  <div className='table-cell align-middle text-sm md:text-base font-bold'>
+                    결제 완료
+                  </div>
+                </li>
+              </>
+            );
+          })}
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export default OrderProducts;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,7 @@ import CheckOut from 'pages/CheckOut';
 import MyPage from 'pages/MyPage';
 import MyPageLayout from 'pages/MyPageLayout';
 import MyPageSetting from 'pages/MyPageSetting';
+import OrderConfirm from 'pages/OrderConfirm';
 
 const router = createBrowserRouter([
   {
@@ -98,6 +99,14 @@ const router = createBrowserRouter([
             ),
           },
         ],
+      },
+      {
+        path: '/order/:id',
+        element: (
+          <ProtectedRoute requireUser>
+            <OrderConfirm />
+          </ProtectedRoute>
+        ),
       },
     ],
   },

--- a/src/pages/MyCart.tsx
+++ b/src/pages/MyCart.tsx
@@ -8,6 +8,7 @@ import { useCartQuery } from 'hooks/useCartQuery';
 import { useNavigate } from 'react-router-dom';
 import OrderProcess from 'components/OrderProcess';
 import { AuthContextType } from 'types/auth';
+import { Link } from 'react-router-dom';
 
 const MyCart = () => {
   const { user } = useAuthContext() as AuthContextType;
@@ -15,6 +16,28 @@ const MyCart = () => {
   const { isLoading, products } = useCartQuery();
 
   if (isLoading) return <p>Loading...</p>;
+  if (!products?.length) {
+    return (
+      <>
+        <OrderProcess />
+        <div className='px-12 pt-12 pb-48'>
+          <div className='pt-20 text-center  text-4xl border-t-4 md:border-b-2 border-black py-24'>
+            <h3 className='text-lg md:text-3xl'>
+              장바구니에 담은 상품이 없습니다.
+            </h3>
+            <div className='flex justify-center mt-10'>
+              <Link
+                to='/'
+                className='flex flex-1 justify-center items-center max-w-60 md:max-w-[400px] h-14 border border-gray-500 text-lg md:text-2xl font-bold'
+              >
+                CONTINUE SHOPPING
+              </Link>
+            </div>
+          </div>
+        </div>
+      </>
+    );
+  }
   const totalPrice = products?.reduce(
     (acc, cur) => (acc += cur.price * cur.quantity),
     0,
@@ -45,12 +68,14 @@ const MyCart = () => {
           <FaEquals size={25} />
           <PriceCard text={'총 결제금액'} price={totalPrice! + SHIPPING} />
         </section>
-        <button
-          className='w-full h-12 text-white text-xl hover:text-orange-700 font-semibold bg-light-brown rounded'
-          onClick={() => navigate('/checkout')}
-        >
-          주문하기
-        </button>
+        {products?.length && (
+          <button
+            className='w-full h-12 text-white text-xl hover:text-orange-700 font-semibold bg-light-brown rounded'
+            onClick={() => navigate('/checkout')}
+          >
+            주문하기
+          </button>
+        )}
       </div>
     </>
   );

--- a/src/pages/OrderConfirm.tsx
+++ b/src/pages/OrderConfirm.tsx
@@ -1,0 +1,45 @@
+import OrderProcess from 'components/OrderProcess';
+import OrderProducts from 'components/OrderProducts';
+import { Link } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
+import { CartItemType } from 'types/product';
+
+const OrderConfirm = () => {
+  const { id } = useParams();
+  const location = useLocation();
+  const products = location.state as CartItemType[];
+  console.log('products', products);
+  return (
+    <div className='px-12 pt-12 pb-48'>
+      <OrderProcess />
+      <div className='w-full flex flex-col border-4 border-black mb-12'>
+        <div className='pb-16'>
+          <h2 className='text-2xl md:text-4xl p-7 font-bold'>
+            주문이 완료되었습니다.
+          </h2>
+        </div>
+        <p className='h-14 flex items-center gap-2 text-sm md:text-lg border-t-2 border-black pl-8'>
+          주문번호
+          <strong className='text-price-stress'>{id}</strong>
+        </p>
+      </div>
+      <OrderProducts products={products} />
+      <div className='flex justify-center items-center gap-3 mt-20'>
+        <Link
+          to='/'
+          className='text-lg md:text-2xl border border-slate-400 p-5 md:px-10 md:py-5 font-semibold'
+        >
+          계속 쇼핑하기
+        </Link>
+        <Link
+          to='/mypage'
+          className='text-lg md:text-2xl border p-5 md:px-10 md:py-5 bg-black text-white font-semibold'
+        >
+          주문/배송조회
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default OrderConfirm;

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -23,7 +23,7 @@ export type Receiver = {
     part2: string;
     part3: string;
   };
-  phone2: {
+  phone2?: {
     part1: string;
     part2: string;
     part3: string;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,6 +15,7 @@ module.exports = {
         'price-stress': '#ff4800',
         'light-black': 'rgb(48, 48, 51)',
         'light-gray': '#5D5D5D',
+        'very-light-gray': '#e4e4e4',
       },
       width: {
         140: '35rem',


### PR DESCRIPTION
## Issue : 🧲 PULL REQUEST

## #️⃣ 연관된 이슈

>  #27 

## 📝 작업 내용
> 장바구니에 담긴 상품이 없는 경우 UI 수정 
> 주문 완료 시 카트에 담긴 상품들 삭제 및 firestore에 저장
> 주문 완료 페이지 스타일링 +  반응형 적용

## 🖼️ 스크린샷 (선택)
>![image](https://github.com/user-attachments/assets/8b7c8783-de45-4252-943e-aeb7f52e2966)
>![image](https://github.com/user-attachments/assets/9f6b19d9-bd86-4029-bb8c-91fc256a8bff)



