### PR TITLE
Feat/checkout 환불 시 주문 데이터 업데이트 및 UI 반영

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ProductCountProvider } from 'context/ProductCountContext';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { TabProvider } from 'context/TabContext';
+import Modal from 'components/Modal';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -28,6 +29,7 @@ function App() {
         <TabProvider>
           <ProductCountProvider>
             <Outlet />
+            <Modal />
             <ToastContainer />
           </ProductCountProvider>
         </TabProvider>

--- a/src/api/order.ts
+++ b/src/api/order.ts
@@ -6,6 +6,7 @@ import {
   orderBy,
   query,
   setDoc,
+  updateDoc,
   where,
 } from 'firebase/firestore';
 import { db } from './firebase';
@@ -99,4 +100,20 @@ export const getOrderDetail: QueryFunction<
     throw new Error('No matching order!');
   }
   return order[0] as OrderList;
+};
+
+export const updateOrder = async ({
+  uid,
+  orderId,
+}: {
+  uid: string;
+  orderId: string;
+}) => {
+  const orderRef = collection(db, 'orders', uid, 'list');
+  const q = query(orderRef, where('orderId', '==', orderId));
+  const querySnapshot = await getDocs(q);
+  if (!querySnapshot.empty) {
+    const docRef = querySnapshot.docs[0].ref;
+    await updateDoc(docRef, { status: 'cancelled' });
+  }
 };

--- a/src/api/order.ts
+++ b/src/api/order.ts
@@ -80,6 +80,30 @@ export const getOrders: QueryFunction<
   return orders;
 };
 
+export const getCancelOrders: QueryFunction<
+  OrderList[],
+  [string, string, string, string]
+> = async ({ queryKey }) => {
+  const [_, uid, _2, cancelled] = queryKey;
+  const q = query(
+    collection(db, `orders/${uid}/list`),
+    where('status', '==', cancelled),
+    orderBy('orderDate', 'desc'),
+  );
+  const orderSnapshot = await getDocs(q);
+  const orders = orderSnapshot.docs.map((doc) => {
+    const data = doc.data();
+    return {
+      ...doc.data(),
+      orderDate: data.orderDate ? data.orderDate.toDate() : new Date(),
+    };
+  }) as OrderList[];
+  if (!orders.length) {
+    throw new Error('No orders found!');
+  }
+  return orders;
+};
+
 export const getOrderDetail: QueryFunction<
   OrderList,
   [string, string, string, string]

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -20,7 +20,7 @@ const Modal = () => {
         </div>
       </div>
     </div>,
-    document.getElementById('modal')!,
+    document.getElementById('modal') as HTMLElement,
   );
 };
 

--- a/src/components/OrderCancelModal.tsx
+++ b/src/components/OrderCancelModal.tsx
@@ -1,13 +1,48 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { updateOrder } from 'api/order';
+import { useAuthContext } from 'context/AuthContext';
 import { handleRefund } from 'lib/payment';
 import { useState } from 'react';
 import { useModalStore } from 'store/modal';
+import { AuthContextType } from 'types/auth';
+import { OrderList } from 'types/order';
 
 const OrderCancelModal = ({ orderId }: { orderId: string }) => {
-  const [message, setMessage] = useState('');
+  const { user } = useAuthContext() as AuthContextType;
   const { closeModal } = useModalStore();
+  const [message, setMessage] = useState('');
+  const queryClient = useQueryClient();
+  const cancelOrder = useMutation({
+    mutationFn: updateOrder,
+    onSuccess: async () => {
+      const queryCache = queryClient.getQueryCache();
+      const queryKeys = queryCache.getAll().map((cache) => cache.queryKey);
+      queryKeys.forEach((queryKey) => {
+        if ((queryKey[0] === 'mypage', queryKey[2] === 'orders')) {
+          const value: OrderList[] | undefined =
+            queryClient.getQueryData(queryKey);
+          if (value) {
+            const order = value.find((v) => v.orderId === orderId);
+            if (order) {
+              const index = value.findIndex((v) => v.orderId === orderId);
+              const shallow = [...value];
+              shallow[index] = {
+                ...shallow[index],
+                status: 'cancelled',
+              };
+              queryClient.setQueryData(queryKey, shallow);
+            }
+          }
+        }
+      });
+    },
+  });
   const handleCancelPay = async () => {
-    const { message } = await handleRefund(orderId);
+    const { isSuccess, message } = await handleRefund(orderId);
     setMessage(message);
+    if (isSuccess) {
+      cancelOrder.mutate({ uid: user?.uid as string, orderId });
+    }
   };
   return (
     <div className='flex flex-col gap-5 text-center leading-6'>

--- a/src/components/OrderList.tsx
+++ b/src/components/OrderList.tsx
@@ -1,7 +1,6 @@
 import { OrderList as OrderListType } from 'types/order';
 import OrderCancelModal from './OrderCancelModal';
 import { useModalStore } from 'store/modal';
-import Modal from './Modal';
 import ArrowSvg from 'assets/svg/ArrowSvg';
 import { Link } from 'react-router-dom';
 
@@ -89,7 +88,6 @@ const OrderList = ({ order }: { order: OrderListType }) => {
           })}
         </ul>
       </div>
-      <Modal />
     </li>
   );
 };

--- a/src/components/OrderProducts.tsx
+++ b/src/components/OrderProducts.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { Fragment } from 'react/jsx-runtime';
 import { CartItemType } from 'types/product';
 
 const OrderProducts = ({ products }: { products: CartItemType[] }) => {
@@ -19,10 +20,10 @@ const OrderProducts = ({ products }: { products: CartItemType[] }) => {
             <div className='table-cell font-bold'>수량</div>
             <div className='table-cell font-bold'>진행 상태</div>
           </li>
-          {products?.map((product) => {
+          {products?.map((product, i) => {
             const { id, name, image, price, size, quantity } = product;
             return (
-              <>
+              <Fragment key={i}>
                 <li className='w-full table table-fixed py-6 border-b last:border-b-2 border-b-black'>
                   <div className='w-8/12 relative table-cell text-center text-base md:text-xl'>
                     <Link to={`/products/${id}`} className='flex items-center'>
@@ -51,7 +52,7 @@ const OrderProducts = ({ products }: { products: CartItemType[] }) => {
                     결제 완료
                   </div>
                 </li>
-              </>
+              </Fragment>
             );
           })}
         </ul>

--- a/src/components/PaymentInfo.tsx
+++ b/src/components/PaymentInfo.tsx
@@ -6,7 +6,6 @@ import { useState } from 'react';
 import { handlePayment } from 'lib/payment';
 import { PHONE_REGEX } from 'utils/checkEffectiveness';
 import { useModalStore } from 'store/modal';
-import Modal from './Modal';
 import MissingInfoModal from './MissingInfoModal';
 import PaymentErrorModal from './PaymentErrorModal';
 import { useCartQuery } from 'hooks/useCartQuery';
@@ -217,7 +216,6 @@ const PaymentInfo = ({ receiver, address }: Props) => {
           </button>
         </div>
       </div>
-      <Modal />
     </section>
   );
 };

--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -15,7 +15,9 @@ const SideBar = () => {
         <li>
           <Link to='/mypage/orders'>주문배송조회</Link>
         </li>
-        <li>취소/교환/반품 내역</li>
+        <li>
+          <Link to='/mypage/cancel-orders'>취소/교환/반품 내역</Link>
+        </li>
       </ul>
       <h4 className='font-bold mb-2'>나의 계정 설정</h4>
       <ul className='text-sm text-light-gray'>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,6 +20,7 @@ import MyPageSetting from 'pages/MyPageSetting';
 import OrderConfirm from 'pages/OrderConfirm';
 import OrderHistory from 'pages/OrderHistory';
 import OrderDetail from 'pages/OrderDetail';
+import CancelOrderHistory from 'pages/CancelOrderHistory';
 
 const router = createBrowserRouter([
   {
@@ -105,6 +106,14 @@ const router = createBrowserRouter([
             element: (
               <ProtectedRoute requireUser>
                 <OrderHistory />
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: 'cancel-orders',
+            element: (
+              <ProtectedRoute requireUser>
+                <CancelOrderHistory />
               </ProtectedRoute>
             ),
           },

--- a/src/pages/CancelOrderHistory.tsx
+++ b/src/pages/CancelOrderHistory.tsx
@@ -1,0 +1,44 @@
+import { DefaultError, useQuery } from '@tanstack/react-query';
+import { getCancelOrders } from 'api/order';
+import OrderList from 'components/OrderList';
+import { useAuthContext } from 'context/AuthContext';
+import { AuthContextType } from 'types/auth';
+import { OrderList as OrderListType } from 'types/order';
+
+const CancelOrderHistory = () => {
+  const { user } = useAuthContext() as AuthContextType;
+  const {
+    isLoading,
+    data: orders,
+    error,
+  } = useQuery<
+    OrderListType[],
+    DefaultError,
+    OrderListType[],
+    [string, string, string, string]
+  >({
+    queryKey: ['mypage', user?.uid as string, 'orders', 'cancelled'],
+    queryFn: getCancelOrders,
+  });
+  if (isLoading) return <p>Loading...</p>;
+
+  return (
+    <div className='w-full'>
+      <h4 className='text-xl text-center sm:text-2xl sm:text-left leading-normal'>
+        주문배송조회
+      </h4>
+      <section className='hidden mt-2 sm:flex border-t-4 border-black'>
+        <div className='flex-1 text-center font-bold p-5'>상품정보</div>
+        <div className='flex-1 text-center font-bold p-5'>배송비</div>
+        <div className='flex-1 text-center font-bold p-5'>진행상태</div>
+      </section>
+      <ol className='border-black sm:last:border-b'>
+        {orders?.map((order) => (
+          <OrderList key={order.orderId} order={order} />
+        ))}
+      </ol>
+    </div>
+  );
+};
+
+export default CancelOrderHistory;


### PR DESCRIPTION
## Issue : 🧲 PULL REQUEST

## #️⃣ 연관된 이슈

>  #27 

## 📝 작업 내용

> Modal 컴포넌트가 중복으로 렌더링되는 문제 해결
> 환불 성공 시 주문 데이터 업데이트 및 UI 반영 및 취소 내역 불러오기

## 🖼️ 스크린샷 (선택)

>주문 내역 조회 및 주문 취소 클릭 시 확인 후 환불 처리 진행
![image](https://github.com/user-attachments/assets/638cbcbc-289d-4364-860c-41d8d5123bc2)

>취소 내역 조회하기
![image](https://github.com/user-attachments/assets/32453f47-86ab-4196-8d69-3fc2257070e3)

